### PR TITLE
Expose linear, Jacobian and Hessian methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 DACE_jll = "40de70a5-cf80-53d9-bda4-3aa67fea2f4f"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 
 [compat]
 CxxWrap = "0.15"

--- a/src/DACE.jl
+++ b/src/DACE.jl
@@ -106,6 +106,11 @@ module DACE
     # wrappers for map inversion
     invert(v::Vector{<:DA}) = Vector{DA}(invert(AlgebraicVector(v)))
 
+    # wrappers for linear part, Jacobian and Hessian
+    linear(v::Vector{<:DA}) = linear(AlgebraicVector(v))
+    jacobian(v::Vector{<:DA}) = jacobian(AlgebraicVector(v))
+    hessian(v::Vector{<:DA}) = stack(hessian(AlgebraicVector(v)), dims=3)
+
     # wrappers for compilation and evaluation of DA objects
     compile(v::Vector{<:DA}) = compile(StdVector{DA}(v))
     for R in (DA, Float64)


### PR DESCRIPTION
Expose `T::linear()`, `T::jacobian()` and `T::hessian()` methods with `T` a `DA` or `AlgebraicVector<DA>` object.