### PR TITLE
Compatibility with NonlinearSolve.jl

### DIFF
--- a/src/DACE.jl
+++ b/src/DACE.jl
@@ -33,8 +33,10 @@ module DACE
     # custom constructors #
     # ------------------- #
 
-    # concrete DA types
+    DA(b::Bool) = DA(b ? 1.0 : 0.0)
     DA(x::Rational) = DA(convert(Float64,x))
+
+    # concrete DA types
     DAAllocated() = DA(0.0)
     DAAllocated(x::Real) = DA(x)
 
@@ -75,6 +77,8 @@ module DACE
     end
 
     Base.float(a::DA) = a
+    Base.eps(a::DA) = eps(cons(a))
+    Base.eps(::Type{T}) where {T<:DA} = eps(Float64)
 
     # power operators
     Base.:^(da::DA, p::Integer) = DACE.powi(da, p)

--- a/test/special_functions.jl
+++ b/test/special_functions.jl
@@ -5,15 +5,15 @@ using SpecialFunctions
         DACE.init(1,3)
 
         x = DACE.random(-1)
-        @test isapprox(DACE.cons(erf(x)), erf(DACE.cons(x)), atol=1e-8, rtol=1e-5)
+        @test isapprox(DACE.cons(erf(x)), erf(DACE.cons(x)), atol=1e-15, rtol=1e-15)
 
     end
 
     @testset "Test erfc" begin
         DACE.init(1,3)
-        
+
         x = DACE.random(-1)
-        @test isapprox(DACE.cons(erfc(x)), erfc(DACE.cons(x)), atol=1e-8, rtol=1e-5)
+        @test isapprox(DACE.cons(erfc(x)), erfc(DACE.cons(x)), atol=1e-15, rtol=1e-15)
 
     end
 


### PR DESCRIPTION
Implement `DA(b::Bool)` and override `Base.eps` for `DA` objects.
This allows to solve nonlinear equations using [NonlinearSolve](https://docs.sciml.ai/NonlinearSolve/stable/) when the independent variable is a DA object.